### PR TITLE
Add University Service and Controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityController.java
@@ -1,9 +1,40 @@
 package edu.ucsb.cs156.spring.backenddemo.controllers;
 
+import edu.ucsb.cs156.spring.backenddemo.services.UniversityQueryService;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.apache.catalina.connector.Response;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+
+@Tag(name="University info from http://universities.hipolabs.com/search")
+@Slf4j
 @RestController
+@RequestMapping("/api/university")
 public class UniversityController {
-    
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    UniversityQueryService universityQueryService;
+
+    @GetMapping("/get")
+    public ResponseEntity<String> getUniversities(@Parameter(name="name", description="name to search", example="Stanford") @RequestParam String name)
+    throws JsonProcessingException {
+        log.info("getUniversities: name={}", name);
+        String result = universityQueryService.getJSON(name);
+        return ResponseEntity.ok().body(result);
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityControllerTests.java
@@ -1,0 +1,46 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.UniversityQueryService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(value = UniversityController.class)
+public class UniversityControllerTests {
+    private ObjectMapper mapper = new ObjectMapper();
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    UniversityQueryService mockUniversityQueryService;
+
+    @Test
+    public void test_getUniversities() throws Exception {
+        String fakeJsonResult = "[{\"web_pages\": [\"http://www.stanford.edu/\"], \"alpha_two_code\": \"US\", \"state-province\": null, \"domains\": [\"stanford.edu\"], \"name\": \"Stanford University\", \"country\": \"United States\"}]";
+        String name = "Stanford";
+        when(mockUniversityQueryService.getJSON(eq(name))).thenReturn(fakeJsonResult);
+        String url = String.format("/api/university/get?name=%s", name);
+        MvcResult response = mockMvc
+        .perform( get(url).contentType("application/json"))
+        .andExpect(status().isOk()).andReturn();
+
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(fakeJsonResult, responseString);
+    }
+}


### PR DESCRIPTION
In this PR, we add an endpoint `/api/university/get` that can be used to get information on universities with the matching name.